### PR TITLE
Changed dev command to use escaped quotes instead of single

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "ENV=development electron .",
-    "dev": "concurrently -k 'babel-node server.js' 'npm start'",
+    "dev": "concurrently -k \"babel-node server.js\" \"npm start\"",
     "build": "webpack --config webpack.config.production.js && electron-packager . CryptoPriceChecker --platform=darwin --arch=all --prune --overwrite --icon ./bitcoin_icns.icns"
   },
   "repository": {


### PR DESCRIPTION
This was needed to run the app on windows, needs to be tested on unix/mac

escaped quotes recommended in concurrently docs
https://www.npmjs.com/package/concurrently#usage
